### PR TITLE
WIP - Env vars

### DIFF
--- a/embark/lib/templates/.env
+++ b/embark/lib/templates/.env
@@ -1,0 +1,7 @@
+# UNCOMENT THE LINE WITH THE ENVIRONMMENT VARIABLE YOU WANT TO OVERRIDE THE DEFAULT VALUE IN DOCKER COMPOSE
+
+# Change here the https port to access the App from your host
+# HTTPS_PORT=9443
+
+# Change here the port to access the metrics from your host
+# METRICS_PORT=5001

--- a/embark/lib/templates/README.md.eex
+++ b/embark/lib/templates/README.md.eex
@@ -1,25 +1,47 @@
 # <%= app_module %>
 
-### Start services
+## Set Environment Variables
+
+Open the `hello_tokumei/.env` file to change environment variables to match your needs.
+
+
+### Https Port
+
+To override the default port from `8443` to `9443`:
+
+```
+HTTPS_PORT=9443
+```
+
+### Metrics Port
+
+To override the default port from `4001` to `5001`
+
+```
+METRICS_PORT=5001
+```
+
+## Start services
 
 ```
 docker-compose up
 ```
 *Use `-d` to run in background.*
 
-- visit https://localhost:8443 *Accept certificate for localhost*
 
-##### For metrics visit
+## Available Urls
 
-- visit http://localhost:4001 to view service metrics.
+* App - visit https://localhost:8443 and *Accept certificate for localhost*
+* Metrics - visit http://localhost:4001 to view service metrics.
 
-### Run tests
+
+## Run tests
 
 ```
 docker-compose run web mix test
 ```
 
-### Rebuild services
+## Rebuild services
 
 Most changes to the source code will automatically be reflected in the running service. However some changes, e.g. to templates and config files require the service to be rebuilt.
 
@@ -27,7 +49,7 @@ Most changes to the source code will automatically be reflected in the running s
 docker-compose build
 ```
 
-### Fetch depenencies
+## Fetch dependencies
 
 ```
 docker-compose run web mix deps.get
@@ -35,7 +57,8 @@ docker-compose run web mix deps.get
 
 *The service will need to be rebuilt after fetching new dependencies*
 
-### Connect to running node
+
+## Connect to running node
 
 Look up container id for running service
 ```

--- a/embark/lib/templates/docker-compose.yml.eex
+++ b/embark/lib/templates/docker-compose.yml.eex
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
   web:
@@ -6,12 +6,12 @@ services:
       context: "."
       dockerfile: "Dockerfile"
     environment:
-      - SECURE_PORT=8443
-      - SERVICE_NAME=web
+      - SECURE_PORT=${HTTPS_PORT:-8443}
+      - SERVICE_NAME=${SERVICE_NAME:-web}
       - ERLANG_COOKIE=<%= :crypto.strong_rand_bytes(64) |> Base.url_encode64 %>
     ports:
-      - 8443:8443
-      - 4001:4001
+      - ${HTTPS_PORT:-8443}:8443
+      - ${METRICS_PORT:-4001}:4001
     volumes:
       - .:/home/elixir/app
     command: sh start.sh


### PR DESCRIPTION
Add support for environment variables from a `.env` file.

This variables will allow to override the new defaults present in `docker-compose.yml`.

To support this environments variables was necessary to upgrade the version required for docker compose to `2.1`.