### PR TITLE
attempt at building integrated image

### DIFF
--- a/embark/lib/templates/Dockerfile
+++ b/embark/lib/templates/Dockerfile
@@ -13,3 +13,11 @@ USER "${CONTAINER_USER}"
 WORKDIR "${APP_DIR}"
 
 RUN mix local.hex --force && mix local.rebar --force
+
+COPY mix.* ./
+COPY config ./config
+RUN mix deps.get && mix deps.compile
+
+COPY . ./
+
+CMD ["mix", "run", "--no-halt"]


### PR DESCRIPTION
The aim of this PR is to make it so that the build container can be run in production without needing to remount the code.
It is still useful to be able to mount the code in development so that generators work and code reloading can be used to speed up development


The line to fetch dependencies runs into file permission errors

```
Step 11/13 : RUN mix deps.get && mix deps.compile
 ---> Running in 244bc3e49f77
Resolving Hex dependencies...
Dependency resolution completed:
  poison 3.1.0
* Getting poison (Hex package)
  Checking package (https://repo.hex.pm/tarballs/poison-3.1.0.tar)
  Fetched package
** (MatchError) no match of right hand side value: {:error, :enoent}
    (hex) src/hex_erl_tar.erl:1668: :hex_erl_tar.write_file/2
    (hex) src/hex_erl_tar.erl:1618: :hex_erl_tar.create_regular/4
    (hex) src/hex_erl_tar.erl:1583: :hex_erl_tar.write_extracted_element/3
    (hex) src/hex_erl_tar.erl:148: :hex_erl_tar.extract2/4
    (hex) src/hex_erl_tar.erl:138: :hex_erl_tar.extract1/4
    (hex) src/hex_erl_tar.erl:1391: :hex_erl_tar.foldl_read1/5
    (hex) src/hex_erl_tar.erl:1357: :hex_erl_tar.foldl_read0/4
    (hex) src/hex_erl_tar.erl:1332: :hex_erl_tar.foldl_read/4
ERROR: Service 'www' failed to build: The command '/bin/sh -c mix deps.get && mix deps.compile' returned a non-zero code: 1
```