### PR TITLE
Add moduledoc to mix task, add explicit link to the favicon in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Includes:
 - `--docker`: Create `Dockerfile` and `docker-compose.yml` in template.
   This allows local development to be conducted completly in docker.
 
-- `--module`: Used to name the top level module used in the generated project. Without this option the module name will be generated from path option.
+- `--module`: Used to name the top level module used in the generated project.
+  Without this option the module name will be generated from path option.
 
   ```sh
   $ mix raxx.kit my_app

--- a/lib/mix/tasks/raxx/kit.ex
+++ b/lib/mix/tasks/raxx/kit.ex
@@ -3,8 +3,37 @@ defmodule Mix.Tasks.Raxx.Kit do
 
   require Mix.Generator
 
-  @shortdoc "Create a new Raxx project for browsers"
+  @shortdoc "Creates a new Raxx project for browsers"
   @switches [docker: :boolean, apib: :boolean, module: :string, node_assets: :boolean]
+
+  @moduledoc """
+  Creates a new Raxx project for browsers.
+
+  It expects the name of the project as the argument.
+
+      mix raxx.kit NAME [--node-assets] [--docker] [--module ModuleName] [--apib]
+
+  ## Options
+
+  - `--node-assets`: Add JavaScript compilation as part of a generated project.
+    Works with or without docker.
+
+  - `--docker`: Create `Dockerfile` and `docker-compose.yml` in template.
+    This allows local development to be conducted completly in docker.
+
+  - `--module`: Used to name the top level module used in the generated project.
+  Without this option the module name will be generated from path option.
+
+  ```sh
+  $ mix raxx.kit my_app
+
+  # Is equivalent to
+  $ mix raxx.kit my_app --module MyApp
+  ```
+
+  - `--apib`: Generate an API Blueprint file which is used as the project router.
+
+  """
 
   @impl Mix.Task
   def run([]) do

--- a/priv/template/lib/app_name/www/_layout.html.eex.eex
+++ b/priv/template/lib/app_name/www/_layout.html.eex.eex
@@ -5,6 +5,7 @@
     <title><%= @name %> </title>
     <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Roboto:300,300italic,700,700italic">
     <link rel="stylesheet" href="/main.css">
+    <link rel="icon" href="/favicon.ico">
   </head>
   <body>
   <%%= content %>


### PR DESCRIPTION
Updated moduledoc in console: 
![moduledoc](https://user-images.githubusercontent.com/140347/40812542-a1f2b490-6536-11e8-974c-6f6704b203dc.png)
