### PR TITLE
Make the generated project use section-style routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Master
+
+### Fixed
+
+- Use `section`-based routes in the generated project to avoid warnings.
+
 ## [0.8.1](https://github.com/CrowdHailer/raxx_kit/tree/0.8.1) - 2018-11-24
 
 ### Fixed

--- a/priv/template/lib/app_name/www.ex.eex
+++ b/priv/template/lib/app_name/www.ex.eex
@@ -1,11 +1,13 @@
 defmodule <%= @module %>.WWW do
   use Ace.HTTP.Service, port: 8080, cleartext: true
-  use Raxx.Server
   <%= if @api_blueprint do %>
+  use Raxx.Server
   @external_resource "lib/<%= @name %>/www.apib"
   use Raxx.ApiBlueprint, "./www.apib"
   <% else %>
-  use Raxx.Router, [
+  use Raxx.Router
+
+  section [], [
     {%{path: []}, <%= @module %>.WWW.HomePage},
     {_, <%= @module %>.WWW.NotFoundPage}
   ]


### PR DESCRIPTION
This stops the generated project for showing warnings on compilation