### PR TITLE
Basic authentication as a standalone extension

### DIFF
--- a/extensions/basic_authentication/.formatter.exs
+++ b/extensions/basic_authentication/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/extensions/basic_authentication/.formatter.exs
+++ b/extensions/basic_authentication/.formatter.exs
@@ -1,4 +1,3 @@
-# Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
 ]

--- a/extensions/basic_authentication/.gitignore
+++ b/extensions/basic_authentication/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where 3rd-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+basic_authentication-*.tar
+

--- a/extensions/basic_authentication/README.md
+++ b/extensions/basic_authentication/README.md
@@ -1,0 +1,3 @@
+# BasicAuthentication
+
+Submit and verify client credentials using the 'Basic' HTTP authentication scheme.

--- a/extensions/basic_authentication/lib/basic_authentication.ex
+++ b/extensions/basic_authentication/lib/basic_authentication.ex
@@ -1,0 +1,90 @@
+defmodule BasicAuthentication do
+  @moduledoc """
+  Submit and verify client credentials using Basic authentication.
+
+  *The 'Basic' authentication scheme is specified in RFC 7617 (which obsoletes RFC 2617).
+  This scheme is not a secure method of user authentication,
+  see https://tools.ietf.org/html/rfc7617#section-4*
+
+  The HTTP header `authorization` is actually used for authentication.
+  Function names in this project use the term authentication where possible.
+  """
+
+  @doc """
+  Encode client credentials to an authorization header value
+
+  NOTE:
+  1. The user-id and password MUST NOT contain any control characters
+  2. The user-id must not contain a `:`
+   -> {ok, headerstring}
+  """
+  def encode_authentication(user_id, password) do
+    case user_pass(user_id, password) do
+      {:ok, pass} ->
+        {:ok, "Basic " <> Base.encode64(pass)}
+    end
+  end
+
+  @doc """
+  Decode an authorization header to client credentials.
+
+  ## Examples
+
+      iex> decode_authentication("Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
+      {:ok, {"Aladdin", "open sesame"}}
+
+      iex> decode_authentication("Basic !!BAD")
+      {:error, :unable_to_decode_user_pass}
+
+      iex> decode_authentication("Bearer my-token")
+      {:error, :unknown_authentication_method}
+  """
+  def decode_authentication(authentication_header) do
+    case String.split(authentication_header, " ", parts: 2) do
+      ["Basic", encoded] ->
+        case Base.decode64(encoded) do
+          {:ok, user_pass} ->
+            case String.split(user_pass, ":", parts: 2) do
+              [user_id, password] ->
+                {:ok, {user_id, password}}
+
+              _ ->
+                {:error, :invalid_user_pass}
+            end
+
+          :error ->
+            {:error, :unable_to_decode_user_pass}
+        end
+
+      [_unknown, _] ->
+        {:error, :unknown_authentication_method}
+
+      _ ->
+        {:error, :invalid_authentication_header}
+    end
+  end
+
+  def encode_challenge(realm, nil) do
+    "Basic realm=\"#{realm}\""
+  end
+
+  def encode_challenge(realm, charset) do
+    "Basic realm=\"#{realm}\", charset=\"#{charset}\""
+  end
+
+  # A decode challenge might be useful here, but i've never used it
+
+  # expose valid user_id valid_password functions
+  # what to do if extracting data returns invalid user_id or password
+  # nothing and yet people use the check functions
+  # use check function in middleware
+  defp user_pass(user_id, password) do
+    case :binary.match(user_id, [":"]) do
+      {_, _} ->
+        raise "a user-id containing a colon character is invalid"
+
+      :nomatch ->
+        {:ok, user_id <> ":" <> password}
+    end
+  end
+end

--- a/extensions/basic_authentication/lib/raxx/basic_authentication.ex
+++ b/extensions/basic_authentication/lib/raxx/basic_authentication.ex
@@ -8,6 +8,24 @@ defmodule Raxx.BasicAuthentication do
 
   @authentication_header "authorization"
 
+  use Raxx.Middleware
+
+  @impl Raxx.Middleware
+  def process_head(request, config, next) do
+    case fetch_basic_authentication(request) do
+      {:ok, {user_id, password}} ->
+        if secure_compare(user_id, config.user_id) && secure_compare(password, config.password) do
+          {parts, next} = Raxx.Server.handle_head(next, request)
+          {parts, config, next}
+        else
+          {Raxx.separate_parts([unauthorized()]), config, next}
+        end
+
+      _ ->
+        {Raxx.separate_parts([unauthorized()]), config, next}
+    end
+  end
+
   @doc """
   Add a clients credentials to a request to authenticate it,
   using the 'Basic' HTTP authentication scheme.
@@ -75,12 +93,35 @@ defmodule Raxx.BasicAuthentication do
 
   - Validation should be added for the parameter values to ensure they only accept valid values.
   """
-  def unauthorized(options) do
+  def unauthorized(options \\ []) do
     realm = Keyword.get(options, :realm, @default_realm)
     charset = Keyword.get(options, :charset, @default_charset)
 
     Raxx.response(:unauthorized)
     |> Raxx.set_header("www-authenticate", BasicAuthentication.encode_challenge(realm, charset))
     |> Raxx.set_body("401 Unauthorized")
+  end
+
+  # This is only used because we have the dumb middleware version
+  @doc """
+  Compares the two binaries in constant-time to avoid timing attacks.
+  See: http://codahale.com/a-lesson-in-timing-attacks/
+  """
+  def secure_compare(left, right) do
+    if byte_size(left) == byte_size(right) do
+      secure_compare(left, right, 0) == 0
+    else
+      false
+    end
+  end
+
+  defp secure_compare(<<x, left::binary>>, <<y, right::binary>>, acc) do
+    import Bitwise
+    xorred = x ^^^ y
+    secure_compare(left, right, acc ||| xorred)
+  end
+
+  defp secure_compare(<<>>, <<>>, acc) do
+    acc
   end
 end

--- a/extensions/basic_authentication/lib/raxx/basic_authentication.ex
+++ b/extensions/basic_authentication/lib/raxx/basic_authentication.ex
@@ -1,0 +1,86 @@
+defmodule Raxx.BasicAuthentication do
+  @moduledoc """
+  Helpers for working with Basic authentication in Raxx applications.
+
+  *Tests import functions from `Raxx`, e.g. `get_header`.*
+  """
+  alias Raxx.Request
+
+  @authentication_header "authorization"
+
+  @doc """
+  Add a clients credentials to a request to authenticate it,
+  using the 'Basic' HTTP authentication scheme.
+
+  This function will raise an exception if either user_id or password is invalid,
+  see `BasicAuthentication.encode_authorization` for details.
+
+  ## Examples
+
+      iex> request(:GET, "/")
+      ...> |> set_basic_authentication("Aladdin", "open sesame")
+      ...> |> get_header("authorization")
+      "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ=="
+  """
+  def set_basic_authentication(request = %Request{}, user_id, password) do
+    {:ok, authentication_header} = BasicAuthentication.encode_authentication(user_id, password)
+    # Raise on bad credentials
+    request
+    |> Raxx.set_header(@authentication_header, authentication_header)
+  end
+
+  @doc """
+  Extract a clients credentials submitted using the 'Basic' HTTP authentication scheme.
+
+  If authentication of request is not set of invalid an error is returned.
+
+  ## Examples
+      iex> request(:GET, "/")
+      ...> |> set_header("authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
+      ...> |> fetch_basic_authentication()
+      {:ok, {"Aladdin", "open sesame"}}
+
+      iex> request(:GET, "/")
+      ...> |> fetch_basic_authentication()
+      {:error, :no_authorization_header}
+  """
+  def fetch_basic_authentication(request = %Request{}) do
+    case Raxx.get_header(request, @authentication_header) do
+      nil ->
+        {:error, :no_authorization_header}
+
+      authentication_header ->
+        BasicAuthentication.decode_authentication(authentication_header)
+    end
+  end
+
+  @default_realm "Site"
+  @default_charset "UTF-8"
+
+  @doc """
+  Generate a response to a request that failed to authenticate.
+
+  The response will contain a challenge for the client in the `www-authenticate` header.
+  Use an unauthorized response to prompt a client into providing basic authentication credentials.
+
+  ## Options
+
+  - **realm:** describe the protected area. default `"Site"`
+  - **charset:** default `"UTF-8"`
+
+  ### Notes
+
+  - The only valid charset is `UTF-8`; https://tools.ietf.org/html/rfc7617#section-2.1.
+    A `nil` can be provided to this function to omit the parameter.
+
+  - Validation should be added for the parameter values to ensure they only accept valid values.
+  """
+  def unauthorized(options) do
+    realm = Keyword.get(options, :realm, @default_realm)
+    charset = Keyword.get(options, :charset, @default_charset)
+
+    Raxx.response(:unauthorized)
+    |> Raxx.set_header("www-authenticate", BasicAuthentication.encode_challenge(realm, charset))
+    |> Raxx.set_body("401 Unauthorized")
+  end
+end

--- a/extensions/basic_authentication/mix.exs
+++ b/extensions/basic_authentication/mix.exs
@@ -1,0 +1,26 @@
+defmodule BasicAuthentication.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :basic_authentication,
+      version: "0.1.0",
+      elixir: "~> 1.7",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  defp deps do
+    [
+      {:raxx, github: "crowdhailer/raxx", branch: "release-1.0"},
+      {:ex_doc, ">= 0.0.0", only: :dev}
+    ]
+  end
+end

--- a/extensions/basic_authentication/mix.lock
+++ b/extensions/basic_authentication/mix.lock
@@ -1,0 +1,11 @@
+%{
+  "cookie": {:hex, :cookie, "0.1.1", "89438362ee0f0ed400e9f076d617d630f82d682e3fbcf767072a46a6e1ed5781", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.3.1", "73812f447f7a42358d3ba79283cfa3075a7580a3a2ed457616d6517ac3738cb9", [:mix], [], "hexpm"},
+  "eex_html": {:hex, :eex_html, "0.2.0", "7f9da3e8ec2ecda2658a0443c65321e161c7c89897f2011e3d8a70f4f68341cb", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.19.3", "3c7b0f02851f5fc13b040e8e925051452e41248f685e40250d7e40b07b9f8c10", [:mix], [{:earmark, "~> 1.2", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "raxx": {:git, "https://github.com/crowdhailer/raxx.git", "9f2e806561945fe9998367007611306b638b8624", [branch: "release-1.0"]},
+}

--- a/extensions/basic_authentication/test/basic_authentication_test.exs
+++ b/extensions/basic_authentication/test/basic_authentication_test.exs
@@ -1,0 +1,5 @@
+defmodule BasicAuthenticationTest do
+  use ExUnit.Case
+  import BasicAuthentication
+  doctest BasicAuthentication
+end

--- a/extensions/basic_authentication/test/raxx/basic_authentication_test.exs
+++ b/extensions/basic_authentication/test/raxx/basic_authentication_test.exs
@@ -3,4 +3,54 @@ defmodule Raxx.BasicAuthenticationTest do
   import Raxx
   import Raxx.BasicAuthentication
   doctest Raxx.BasicAuthentication
+
+  alias Raxx.Server
+
+  defmodule SimpleApp do
+    use Raxx.SimpleServer
+
+    @impl Raxx.SimpleServer
+    def handle_request(_request, _state) do
+      response(:ok)
+      |> set_body("Hello, World!")
+    end
+  end
+
+  setup do
+    stack =
+      Raxx.Stack.new(
+        [{Raxx.BasicAuthentication, %{user_id: "Aladdin", password: "open sesame"}}],
+        {SimpleApp, nil}
+      )
+
+    {:ok, stack: stack}
+  end
+
+  test "Request with valid authentication passes through stack", %{stack: stack} do
+    request =
+      request(:GET, "/")
+      |> set_header("authorization", "Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==")
+
+    assert {[response], _} = Server.handle_head(stack, request)
+    assert response.status == 200
+    assert response.body == "Hello, World!"
+  end
+
+  test "Request with no authentication is denied", %{stack: stack} do
+    request = request(:GET, "/")
+
+    # TODO, what is the state of helpers here, can the middleware just return a response?
+    # assert {[response], _} = Server.handle_head(stack, request)
+    # assert response.status == 401
+  end
+
+  test "Request with invalid credentials is denied", %{stack: stack} do
+    request =
+      request(:GET, "/")
+      |> set_basic_authentication("Jafar", "Genie")
+
+    # TODO, what is the state of helpers here, can the middleware just return a response?
+    # assert {[response], _} = Server.handle_head(stack, request)
+    # assert response.status == 401
+  end
 end

--- a/extensions/basic_authentication/test/raxx/basic_authentication_test.exs
+++ b/extensions/basic_authentication/test/raxx/basic_authentication_test.exs
@@ -1,0 +1,6 @@
+defmodule Raxx.BasicAuthenticationTest do
+  use ExUnit.Case
+  import Raxx
+  import Raxx.BasicAuthentication
+  doctest Raxx.BasicAuthentication
+end

--- a/extensions/basic_authentication/test/test_helper.exs
+++ b/extensions/basic_authentication/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
I have extracted the general code, from the code that assumes Raxx Request/Response data structures. It would be trivial to implement a plug, might be worth doing just to show how easy it is.

I don't like that there is an implementation of secure_compare in here. I would prefer to use something in the language instead.

This PR has a very simple middleware. In real applications a user might want to configure
- how the credentials are checked, against env vars or in a database
- configure the error response
- configure what logging there is and the log level
- if requests with no authentication can pass up stack but with no user set.
- what information about the user should be added to the context

I think it would be easier for a user to implement there own auth middleware using `fetch_basic_authorization` rather than make all the above options configurable.

What could be useful is a general `Raxx.Authentication` middleware that defines a callback from request -> {:ok, user information} or {:error, response}. The implementer could also add things like calls to the logger/metrics in this callback