### PR TITLE
Only add db section to docker-compose when setting up ecto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.9.1](https://github.com/CrowdHailer/raxx_kit/tree/0.9.1) - 2019-01-10
+
+### Fixed
+
+- Using both `--docker` and `--ecto` now correctly creates the `docker-compose.yml` filed.
+
 ## [0.9.1](https://github.com/CrowdHailer/raxx_kit/tree/0.9.1) - 2019-01-07
 
 ### Added

--- a/priv/template/docker-compose.yml.eex
+++ b/priv/template/docker-compose.yml.eex
@@ -5,11 +5,11 @@ services:
     build:
       context: "."
       dockerfile: "Dockerfile"
-    depends_on:
+    <%= if @ecto do %>depends_on:
       - db
     environment:
       - "DATABASE_URL=ecto://<%= @ecto.db_username %>:<%= @ecto.db_password %>@db:5432/<%= @ecto.db_name %>?ssl=false&pool_size=10"
-    ports:
+    <% end %>ports:
       - 8080:8080
       - 8443:8443
     volumes:
@@ -18,12 +18,12 @@ services:
       ## container's deps/ and _build/ directories in your local project,
       ## under container_mix
       # - ./container_mix_artifacts:/opt/mix_artifacts
-
+  <%= if @ecto do %>
   db:
     image: "postgres:9.6.11"
     environment:
       - POSTGRES_USER=<%= @ecto.db_username %>
       - POSTGRES_PASSWORD=<%= @ecto.db_password %>
     ports:
-      - 6543:5432
+      - 6543:5432<% end %>
 <% end %>


### PR DESCRIPTION
currently running `mix raxx.kit aaa --docker` gives:

```
** (UndefinedFunctionError) function false.db_username/0 is undefined (module false is not available)
    false.db_username()
    (stdlib) erl_eval.erl:677: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:273: :erl_eval.expr/5
    (stdlib) eval_bits.erl:88: :eval_bits.eval_field/3
    (stdlib) eval_bits.erl:68: :eval_bits.expr_grp/4
    (stdlib) erl_eval.erl:481: :erl_eval.expr/5
    (stdlib) eval_bits.erl:88: :eval_bits.eval_field/3
    (stdlib) eval_bits.erl:68: :eval_bits.expr_grp/4
```