### PR TITLE
Update Dockerfile to Elixir 1.8.2

### DIFF
--- a/priv/template/Dockerfile.eex
+++ b/priv/template/Dockerfile.eex
@@ -1,4 +1,4 @@
-<%= if @docker do %>FROM elixir:1.7.4
+<%= if @docker do %>FROM elixir:1.8.2
 
 # NOTE the WORKDIR should not be the users home dir as the will copy container cookie into host machine
 WORKDIR /opt/app


### PR DESCRIPTION
The mix file sets Elixir to 1.8.2 so the Dockerfile should follow suit. I'm currently getting this error on build:
```
** (Mix) You're trying to run :red4 on Elixir v1.7.4 but it has declared in its mix.exs file it supports only Elixir ~> 1.8.2
```