### PR TITLE
fix raxx.new failing on Elixir 1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.12.1](https://github.com/CrowdHailer/raxx_kit/tree/0.12.0) - 2019-06-29
+
+### Fixed
+
+- Mix task `raxx.new` updated to work with Elixir 1.9.
+
 ## [0.12.0](https://github.com/CrowdHailer/raxx_kit/tree/0.12.0) - 2019-05-02
 
 ### Added

--- a/lib/raxx/kit.ex
+++ b/lib/raxx/kit.ex
@@ -15,7 +15,8 @@ defmodule Raxx.Kit do
     # TODO check if dir exists
     config = check_config!(options)
 
-    :ok = Mix.Generator.create_directory(config.name)
+    # This calls File.mkdir_p!/1 and may raise a `File.Error` exception
+    Mix.Generator.create_directory(config.name)
 
     File.cd!(config.name, fn ->
       assigns = Map.from_struct(config)


### PR DESCRIPTION
Thanks for this project! I've been really enjoying the simplicity of the interface. 

`raxx.new` fails on Elixir 1.9 due to what appears to be a different return value from `Mix.Generator.create_directory`.  

```
> mix raxx.new project
* creating project
** (MatchError) no match of right hand side value: true
    lib/raxx/kit.ex:18: Raxx.Kit.generate/1
    lib/mix/tasks/raxx/new.ex:64: Mix.Tasks.Raxx.New.run/1
    (mix) lib/mix/task.ex:331: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:79: Mix.CLI.run_task/2
```

It looks like it used to return `:ok`, and now it always returns `true`. To not break backwards compatibility with different Elixir versions, I didn't match with `true`, but just ignored the return value instead. After this change it works on Elixir 1.9 for me. 